### PR TITLE
Add support to deploy to AWS via Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 node_modules/*
+.terraform

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,37 @@
+# Amazon Web Services Deployment
+
+Deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface](http://aws.amazon.com/cli/). It requires some setup in your Amazon account, editing a configuration file, and creating Amazon resources.
+
+## Dependencies
+
+Install [Terraform](https://terraform.io) using the steps detailed on the project website.
+
+## Configure an AWS Profile using the AWS CLI
+
+Using the AWS CLI, create an AWS profile:
+
+```bash
+$ aws --profile transit configure
+AWS Access Key ID [****************F2DQ]:
+AWS Secret Access Key [****************TLJ/]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Packer, Terraform, and the AWS CLI.
+
+## Terraform
+
+Next, use Terraform to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ AWS_DEFAULT_REGION="us-east-1" AWS_PROFILE="transit" ./scripts/terraform-plan.sh
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ AWS_DEFAULT_REGION="us-east-1" AWS_PROFILE="transit" ./scripts/terraform-apply.sh
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of `deployment/terraform/terraform.tfvars`.

--- a/deployment/scripts/terraform-apply.sh
+++ b/deployment/scripts/terraform-apply.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+if env | grep -q "TA_DEPLOY_DEBUG"; then
+    set -x
+fi
+
+LOCAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${LOCAL_DIR}/../../deployment/terraform"
+
+pushd "${TERRAFORM_DIR}"
+
+terraform remote config \
+          -backend="s3" \
+          -backend-config="bucket=com.azavea.transitanalyst.terraform" \
+          -backend-config="key=state"
+terraform apply "$@"
+terraform remote push

--- a/deployment/scripts/terraform-plan.sh
+++ b/deployment/scripts/terraform-plan.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+if env | grep -q "TA_DEPLOY_DEBUG"; then
+    set -x
+fi
+
+LOCAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${LOCAL_DIR}/../../deployment/terraform"
+
+pushd "${TERRAFORM_DIR}"
+
+terraform remote config \
+          -backend="s3" \
+          -backend-config="bucket=com.azavea.transitanalyst.terraform" \
+          -backend-config="key=state" \
+          -backend-config="encrypt=true"
+
+terraform get -update
+terraform plan -input=false "$@"

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -95,6 +95,13 @@ resource "aws_elb" "app" {
   }
 }
 
+resource "aws_app_cookie_stickiness_policy" "app" {
+  name = "transitanalyst"
+  load_balancer = "${aws_elb.app.name}"
+  lb_port = 80
+  cookie_name = "transitanalyst"
+}
+
 #
 # AutoScaling resources
 #

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -1,0 +1,136 @@
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+resource "aws_sns_topic" "global" {
+  name = "topicTransitAnalyst"
+}
+
+resource "aws_security_group" "app_elb" {
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr}"]
+  }
+
+  tags {
+    Name = "sgTransitAnalystAppServerLoadBalancer"
+  }
+}
+
+resource "aws_security_group" "app" {
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${var.inbound_cidr}"]
+  }
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.app_elb.id}"]
+  }
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "sgTransitAnalystAppServer"
+  }
+}
+
+#
+# Elastic Load Balancer resources
+#
+resource "aws_elb" "app" {
+  security_groups = ["${aws_security_group.app_elb.id}"]
+  subnets         = ["${split(",", var.vpc_subnets)}"]
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
+  health_check {
+    healthy_threshold   = 3
+    unhealthy_threshold = 2
+    timeout             = 3
+    target              = "HTTP:80/"
+    interval            = 30
+  }
+
+  cross_zone_load_balancing   = true
+  connection_draining         = true
+  connection_draining_timeout = 300
+
+  tags {
+    Name = "elbTransitAnalystAppServer"
+  }
+}
+
+#
+# AutoScaling resources
+#
+resource "aws_launch_configuration" "app" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  image_id             = "${var.app_ami}"
+  instance_type        = "${var.app_instance_type}"
+  key_name             = "${var.aws_key_name}"
+  security_groups      = ["${aws_security_group.app.id}"]
+}
+
+resource "aws_autoscaling_group" "app" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  # Explicitly linking ASG and launch configuration by name
+  # to force replacement on launch configuration changes.
+  name = "${aws_launch_configuration.app.name}"
+
+  launch_configuration      = "${aws_launch_configuration.app.name}"
+  health_check_grace_period = 600
+  health_check_type         = "ELB"
+  desired_capacity          = "${var.app_desired_capacity}"
+  min_size                  = "${var.app_min_asg_size}"
+  max_size                  = "${var.app_max_asg_size}"
+  min_elb_capacity          = "${var.app_min_elb_capacity}"
+  vpc_zone_identifier       = ["${split(",", var.vpc_subnets)}"]
+  load_balancers            = ["${aws_elb.app.id}"]
+
+  tag {
+    key                 = "Name"
+    value               = "TransitAnalystAppServer"
+    propagate_at_launch = true
+  }
+}

--- a/deployment/terraform/terraform.tfvars
+++ b/deployment/terraform/terraform.tfvars
@@ -1,0 +1,15 @@
+aws_availability_zones = "us-east-1c,us-east-1d"
+aws_key_name = "otp-transit-analyst"
+
+inbound_cidr = "96.93.19.137/32"
+
+vpc_id = "vpc-9853e6fd"
+vpc_cidr = "172.30.0.0/16"
+vpc_subnets = "subnet-65fc2912,subnet-c4f3049d"
+
+app_ami = "ami-6d2a1107"
+app_instance_type = "m4.xlarge"
+app_desired_capacity = "2"
+app_min_asg_size = "2"
+app_max_asg_size = "5"
+app_min_elb_capacity = "2"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,43 @@
+variable "aws_region" {
+  default = "us-east-1"
+}
+
+variable "aws_availability_zones" {
+}
+
+variable "aws_key_name" {
+}
+
+variable "inbound_cidr" {
+}
+
+variable "vpc_id" {
+}
+
+variable "vpc_cidr" {
+}
+
+variable "vpc_subnets" {
+}
+
+variable "app_ami" {
+}
+
+variable "app_instance_type" {
+}
+
+variable "app_desired_capacity" {
+  default = 1
+}
+
+variable "app_min_asg_size" {
+  default = 1
+}
+
+variable "app_max_asg_size" {
+  default = 1
+}
+
+variable "app_min_elb_capacity" {
+  default = 1
+}


### PR DESCRIPTION
Assemble a fleet on Transit Analyst application servers with an AutoScaling group (ASG), and connect them to an Elastic Load Balancer (ELB).

As of right now, the ASG is set to 2. When you want to increase the number of application servers, ensure that you update these attributes together:
- `app_desired_capacity`
- `app_min_elb_capacity`

See `README` for more deployment details.
